### PR TITLE
Upgrade to recommended seed version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ wasm-bindgen = "^0.2.62"
 ordered-float = "1.0.2"
 anymap = "0.12.1"
 derive_more = "0.99.5"
-seed = "0.7.0"
+# This commit points to Seed 0.7.0 with important fixes.
+seed = { git = "https://github.com/seed-rs/seed", rev = "0a538f0" }
 seed_hooks = "0.1.4"
 objekt-clonable = "0.2.2"
 eager = "0.1.0"

--- a/seed_style_macros/Cargo.toml
+++ b/seed_style_macros/Cargo.toml
@@ -26,7 +26,8 @@ quote = "1.0.3"
 proc-macro2 = "1.0.10"
 heck = "0.3.1"
 eager = "0.1.0"
-seed = "0.7.0"
+# This commit points to Seed 0.7.0 with important fixes.
+seed = { git = "https://github.com/seed-rs/seed", rev = "0a538f0" }
 darling = "0.10.2"
 illicit = "0.9.2"
 seed_hooks = "0.1.3"


### PR DESCRIPTION
https://github.com/seed-rs/seed-quickstart/blob/c38c35201eb1eb90241f76805c27d9cf4e8cf19b/Cargo.toml#L19-L21

This version of seed is the recommended version by the seed-quickstarts.

The seed versions have to be equal because using the recommended seed with `
seed_style_preview ` results in type conflicts without this change.

Everything seems to work fine using this version of Seed.