### PR TITLE
Add typed version of justify_content("space-between")

### DIFF
--- a/src/style/css_values.rs
+++ b/src/style/css_values.rs
@@ -2333,6 +2333,8 @@ pub enum CssJustifyContent {
     FlexEnd,
     #[display(fmt = "baseline")]
     Baseline,
+    #[display(fmt = "space-between")]
+    SpaceBetween,
     #[display(fmt = "initial")]
     Initial,
     #[display(fmt = "inherit")]


### PR DESCRIPTION
I am refactoring my style code and will be contributing anything I think is missing back.

Hope this is useful.